### PR TITLE
Feature/22 Discriminate which branch is updated by commit logs

### DIFF
--- a/pushDoxygen.bat
+++ b/pushDoxygen.bat
@@ -22,7 +22,7 @@ if "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (
         if exist latex (rd latex /s /q)
         cd html
         git add --all .
-        git commit -m "auto commit doxygen products by AppVeyor" -m %APPVEYOR_REPO_COMMIT%
+        git commit -m "auto commit doxygen products (develop version) by AppVeyor" -m %APPVEYOR_REPO_COMMIT%
         git push --quiet https://%GitHubAccessToken%@github.com/Geroshabu/GeroMachine gh-pages
     )
 )


### PR DESCRIPTION
Issue : #22
- [x] develop にマージしたら, gh-pages ブランチのコミットログに (develop version) と追記されている.
